### PR TITLE
Fixed bug - google calendar event month was off-by-one

### DIFF
--- a/js/examsCalendar.js
+++ b/js/examsCalendar.js
@@ -36,7 +36,7 @@ function parseRow(row){
     tempHours = row[3].innerText.split(":")
     data = new Date();
     data.setDate(tempDate[0]);
-    data.setMonth(tempDate[1]);
+    data.setMonth(tempDate[1]-1);
     data.setFullYear(tempDate[2]);
     data.setHours(tempHours[0],tempHours[1],0);
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PACO UA Extension",
-    "version": "0.23",
+    "version": "0.24",
 
     "description": "Adiciona funcionalidade ao antigo PACO da Universidade de Aveiro",
 


### PR DESCRIPTION
When creating a google calendar event via the button, all the info would be correct except for the month of the exam, which would be set to the following month. So an exam on September 6th became October 6th.

The error occurs here, in examsCalendar.js:
```
data = new Date();
data.setDate(tempDate[0]);
data.setMonth(tempDate[1]);
data.setFullYear(tempDate[2]);    
``` 

where  ` data.setMonth(tempDate[1]); ` should be `data.setMonth(tempDate[1]-1);`

This is due to the fact that Date.setMonth() expects the argument to start at zero. (January = 0)
See [this](https://www.w3schools.com/jsref/jsref_setmonth.asp). 

@DCruzDev @rodrigogonegit 