### PR TITLE
Fixed abbreviation of subjects name when adding exams to Calendar

### DIFF
--- a/js/examsCalendar.js
+++ b/js/examsCalendar.js
@@ -17,7 +17,7 @@ function parseRow(row){
     var disciplina, data, codigo, sala, epoca;
     var link;
 
-    tempD = row[2].innerText.replace(" DE ", " ").replace(" E "," ").split(" ");
+    tempD = row[2].innerText.replace(" DE ", " ").replace(" E "," ").replace(" À "," ").replace(" AOS "," ").split(" ");
     disciplina = "";
     for (var j = 0; j < tempD.length; j++){
         disciplina = disciplina + tempD[j][0];

--- a/js/examsCalendar.js
+++ b/js/examsCalendar.js
@@ -17,10 +17,16 @@ function parseRow(row){
     var disciplina, data, codigo, sala, epoca;
     var link;
 
-    tempD = row[2].innerText.replace(" DE ", " ").replace(" E "," ").replace(" À "," ").replace(" AOS "," ").split(" ");
+    tempD = row[2].innerText.replace(" DE ", " ").replace(" E "," ").replace(" À "," ").replace(" AOS "," ").replace(" PARA "," ").split(" ");
     disciplina = "";
     for (var j = 0; j < tempD.length; j++){
-        disciplina = disciplina + tempD[j][0];
+        //Check if 'I' is a letter or a roman number
+        if (tempD[j][0] == "I" && tempD[j][1] == "I")
+            //If number, write the whole number
+            disciplina = disciplina + tempD[j];
+        else
+            //If not, write just the first letter
+        	disciplina = disciplina + tempD[j][0];
     }
     codigo = row[1].innerText;
     sala = row[4].innerText;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PACO UA Extension",
-    "version": "0.26",
+    "version": "0.27",
 
     "description": "Adiciona funcionalidade ao antigo PACO da Universidade de Aveiro",
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "PACO UA Extension",
-    "version": "0.25",
+    "version": "0.26",
 
     "description": "Adiciona funcionalidade ao antigo PACO da Universidade de Aveiro",
 


### PR DESCRIPTION
@DCruzDev While exporting an exam to Google Calendar, I realized that the extension ignores Roman numbers when it comes to continuation subjects.

My pull request fixes this by checking if the letter "I" is really a letter or if it's 1 in the roman numbering (by seeing the next letter).
It also fixes the correct abbreviation of the name of some subjects, by ignoring more unnecessary intermediate words such as "PARA" and "AOS", when splitting the full name.

I'm not good with words but the new code is all commented on and the examples below are pretty self explanatory:

#### Input:
```
INTRODUÇÃO À INTELIGÊNCIA ARTIFICIAL
INTRODUÇÃO AOS SISTEMAS DIGITAIS
MÉTODOS PROBABILÍSTICOS PARA ENGENHARIA INFORMÁTICA
PROGRAMAÇÃO III
CÁLCULO II
```
#### Output before changes:
```
IÀIA
IASD
MPPEI
PI
CI
```
#### Output after changes:
```
IIA
ISD
MPEI
PIII
CII
```